### PR TITLE
feat: on-demand webhook + idle watchdog for ECS game servers

### DIFF
--- a/lambda/ecs_webhook.py
+++ b/lambda/ecs_webhook.py
@@ -1,0 +1,72 @@
+import hmac
+import json
+import logging
+import os
+
+import boto3
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+# Module-level cache — populated on cold start
+_token: str = ""
+_ecs_client = boto3.client("ecs")
+
+
+def _load_token() -> str:
+    global _token
+    if _token:
+        return _token
+    ssm = boto3.client("ssm")
+    resp = ssm.get_parameter(
+        Name=os.environ["WEBHOOK_TOKEN_SSM_PATH"],
+        WithDecryption=True,
+    )
+    _token = resp["Parameter"]["Value"]
+    return _token
+
+
+def _response(status_code: int, body: dict) -> dict:
+    return {
+        "statusCode": status_code,
+        "headers": {"Content-Type": "application/json"},
+        "body": json.dumps(body),
+    }
+
+
+def handler(event, context) -> dict:
+    # Function URL events have requestContext.http; other invocations do not.
+    is_url_invocation = bool(event.get("requestContext", {}).get("http"))
+
+    if is_url_invocation:
+        headers = {k.lower(): v for k, v in (event.get("headers") or {}).items()}
+        provided = headers.get("x-webhook-token", "")
+        expected = _load_token()
+        if not hmac.compare_digest(provided, expected):
+            logger.warning("Rejected request: invalid or missing token")
+            return _response(403, {"error": "forbidden"})
+
+        try:
+            body = json.loads(event.get("body") or "{}")
+        except (json.JSONDecodeError, TypeError):
+            return _response(400, {"error": "invalid body"})
+        action = body.get("action")
+    else:
+        # Internal invocation (e.g. direct Lambda invoke with {"action": "start"})
+        action = event.get("action", "stop")
+
+    if action not in ("start", "stop"):
+        return _response(400, {"error": "invalid action"})
+
+    desired_count = 1 if action == "start" else 0
+    cluster_arn = os.environ["ECS_CLUSTER_ARN"]
+    service_name = os.environ["ECS_SERVICE_NAME"]
+
+    logger.info(f"action={action} desired_count={desired_count} service={service_name}")
+    _ecs_client.update_service(
+        cluster=cluster_arn,
+        service=service_name,
+        desiredCount=desired_count,
+    )
+
+    return _response(200, {"status": "ok", "desired_count": desired_count})

--- a/lambda/ecs_webhook.py
+++ b/lambda/ecs_webhook.py
@@ -4,6 +4,7 @@ import logging
 import os
 
 import boto3
+import botocore.exceptions
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -18,10 +19,20 @@ def _load_token() -> str:
     if _token:
         return _token
     ssm = boto3.client("ssm")
-    resp = ssm.get_parameter(
-        Name=os.environ["WEBHOOK_TOKEN_SSM_PATH"],
-        WithDecryption=True,
-    )
+    try:
+        resp = ssm.get_parameter(
+            Name=os.environ["WEBHOOK_TOKEN_SSM_PATH"],
+            WithDecryption=True,
+        )
+    except botocore.exceptions.ClientError as e:
+        if e.response["Error"]["Code"] == "ParameterNotFound":
+            logger.error(
+                "Webhook token not configured. Run: aws ssm put-parameter "
+                "--name %s --type SecureString --value <your-secret>",
+                os.environ["WEBHOOK_TOKEN_SSM_PATH"],
+            )
+            return ""  # empty string — compare_digest("", expected) returns False → 403
+        raise
     _token = resp["Parameter"]["Value"]
     return _token
 

--- a/lib/aws_common/iam.py
+++ b/lib/aws_common/iam.py
@@ -63,3 +63,12 @@ def asg_update_policy(resources: List) -> iam.PolicyStatement:
         ],
         resources=resources,
     )
+
+
+def ssm_get_parameter_policy(resources: List) -> iam.PolicyStatement:
+    """Allow reading SSM parameters (including SecureString with aws/ssm key)"""
+    return iam.PolicyStatement(
+        effect=iam.Effect.ALLOW,
+        actions=["ssm:GetParameter"],
+        resources=resources,
+    )

--- a/lib/config/__init__.py
+++ b/lib/config/__init__.py
@@ -38,3 +38,20 @@ class GameProperties:
     instance_type: str = "t3a.large"
     instance_connect: bool = False
     max_mib_memory: int = 3072
+    webhook_enabled: bool = False
+    idle_shutdown_minutes: int = 20
+    cloudwatch_metric_namespace: Optional[str] = None
+    cloudwatch_player_count_metric: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        cw_fields = (self.cloudwatch_metric_namespace, self.cloudwatch_player_count_metric)
+        if any(cw_fields) and not all(cw_fields):
+            raise ValueError(
+                "cloudwatch_metric_namespace and cloudwatch_player_count_metric "
+                "must both be set or both be None"
+            )
+        if self.idle_shutdown_minutes <= 0 or self.idle_shutdown_minutes % 5 != 0:
+            raise ValueError(
+                f"idle_shutdown_minutes must be a positive multiple of 5, "
+                f"got {self.idle_shutdown_minutes}"
+            )

--- a/lib/config/minecraft.py
+++ b/lib/config/minecraft.py
@@ -70,4 +70,9 @@ MINECRAFT_PROPS = GameProperties(
     instance_type="t4g.large",
     instance_connect=False,
     max_mib_memory=MAX_MEMORY,
+    webhook_enabled=True,
+    idle_shutdown_minutes=20,
+    # Confirm these values in CloudWatch > Metrics after first run:
+    # cloudwatch_metric_namespace="Minecraft",
+    # cloudwatch_player_count_metric="players_online",
 )

--- a/lib/stacks/game_stack.py
+++ b/lib/stacks/game_stack.py
@@ -564,7 +564,5 @@ class GameStack(Stack):
         )
 
         topic = sns.Topic(self, self.qualify_name("WatchdogTopic"))
-        topic.add_subscription(
-            sns_subscriptions.LambdaSubscription(self.task_count_lambda)
-        )
+        topic.add_subscription(sns_subscriptions.LambdaSubscription(self.task_count_lambda))
         alarm.add_alarm_action(cw_actions.SnsAction(topic))

--- a/lib/stacks/game_stack.py
+++ b/lib/stacks/game_stack.py
@@ -1,6 +1,7 @@
 from functools import cached_property
 
 from aws_cdk import Duration, Stack, Tags
+from aws_cdk import aws_ssm as ssm
 from aws_cdk import aws_applicationautoscaling as appscaling
 from aws_cdk import aws_autoscaling as autoscaling
 from aws_cdk import aws_backup as backup
@@ -15,7 +16,13 @@ from aws_cdk import aws_logs as logs
 from constructs import Construct
 
 from lib.aws_common.ec2 import create_security_group
-from lib.aws_common.iam import ec2_instances_read, ecs_cluster_read_policy, r53_update_policy
+from lib.aws_common.iam import (
+    ec2_instances_read,
+    ecs_cluster_read_policy,
+    ecs_cluster_update_policy,
+    r53_update_policy,
+    ssm_get_parameter_policy,
+)
 from lib.config import GameProperties, PortType, ServiceType
 
 
@@ -26,6 +33,9 @@ class GameStack(Stack):
         self.props = props
 
         self.service = self.create_game_service()
+
+        if self.props.webhook_enabled:
+            self.create_webhook_lambda()
 
         if self.props.auto_start and self.props.service_type == ServiceType.EC2:
             self._create_asg_scheduled_actions()
@@ -439,4 +449,56 @@ class GameStack(Stack):
                 handler=function,
             ),
         )
+        return function
+
+    def create_webhook_lambda(self) -> _lambda.Function:
+        """Lambda with Function URL for external start/stop webhook"""
+        name = self.qualify_name("WebhookLambda")
+        ssm_token_path = f"/{self.props.name.lower()}/webhook-token"
+        ssm_token_arn = Stack.of(self).format_arn(
+            service="ssm",
+            resource="parameter",
+            resource_name=f"{self.props.name.lower()}/webhook-token",
+        )
+
+        function = _lambda.Function(
+            scope=self,
+            id=name,
+            function_name=name,
+            handler="ecs_webhook.handler",
+            runtime=_lambda.Runtime.PYTHON_3_14,
+            code=_lambda.Code.from_asset("./lambda"),
+            architecture=_lambda.Architecture.ARM_64,
+            timeout=Duration.seconds(30),
+            initial_policy=[
+                ssm_get_parameter_policy(resources=[ssm_token_arn]),
+                ecs_cluster_update_policy(resources=[self.service.service_arn]),
+                ecs_cluster_read_policy(
+                    resources=[self.cluster.cluster_arn, self.service.service_arn]
+                ),
+            ],
+            environment={
+                "ECS_CLUSTER_ARN": self.cluster.cluster_arn,
+                "ECS_SERVICE_NAME": self.service.service_name,
+                "WEBHOOK_TOKEN_SSM_PATH": ssm_token_path,
+            },
+            log_group=logs.LogGroup(
+                self,
+                f"{name}LogGroup",
+                log_group_name=f"/{self.props.name.lower()}/{name}",
+                retention=logs.RetentionDays.ONE_WEEK,
+            ),
+        )
+
+        url = function.add_function_url(
+            auth_type=_lambda.FunctionUrlAuthType.NONE,
+        )
+
+        ssm.StringParameter(
+            self,
+            self.qualify_name("WebhookUrlParam"),
+            parameter_name=f"/{self.props.name.lower()}/webhook-url",
+            string_value=url.url,
+        )
+
         return function

--- a/lib/stacks/game_stack.py
+++ b/lib/stacks/game_stack.py
@@ -4,6 +4,8 @@ from aws_cdk import Duration, Stack, Tags
 from aws_cdk import aws_applicationautoscaling as appscaling
 from aws_cdk import aws_autoscaling as autoscaling
 from aws_cdk import aws_backup as backup
+from aws_cdk import aws_cloudwatch as cloudwatch
+from aws_cdk import aws_cloudwatch_actions as cw_actions
 from aws_cdk import aws_ec2 as ec2
 from aws_cdk import aws_ecs as ecs
 from aws_cdk import aws_efs as efs
@@ -12,6 +14,8 @@ from aws_cdk import aws_events_targets as targets
 from aws_cdk import aws_iam as iam
 from aws_cdk import aws_lambda as _lambda
 from aws_cdk import aws_logs as logs
+from aws_cdk import aws_sns as sns
+from aws_cdk import aws_sns_subscriptions as sns_subscriptions
 from aws_cdk import aws_ssm as ssm
 from constructs import Construct
 
@@ -36,6 +40,9 @@ class GameStack(Stack):
 
         if self.props.webhook_enabled:
             self.create_webhook_lambda()
+
+        if self.props.cloudwatch_metric_namespace and self.props.cloudwatch_player_count_metric:
+            self.create_idle_watchdog_alarm()
 
         if self.props.auto_start and self.props.service_type == ServiceType.EC2:
             self._create_asg_scheduled_actions()
@@ -504,3 +511,60 @@ class GameStack(Stack):
         )
 
         return function
+
+    @cached_property
+    def task_count_lambda(self) -> _lambda.Function:
+        """Lambda that sets ECS service desiredCount — used by the watchdog SNS alarm"""
+        name = self.qualify_name("TaskCountLambda")
+        return _lambda.Function(
+            scope=self,
+            id=name,
+            function_name=name,
+            handler="ecs_desired_task_count.handler",
+            runtime=_lambda.Runtime.PYTHON_3_14,
+            code=_lambda.Code.from_asset("./lambda"),
+            architecture=_lambda.Architecture.ARM_64,
+            timeout=Duration.seconds(30),
+            initial_policy=[
+                ecs_cluster_update_policy(resources=[self.service.service_arn]),
+            ],
+            environment={
+                "ECS_CLUSTER_ARN": self.cluster.cluster_arn,
+                "ECS_SERVICE_NAME": self.service.service_name,
+            },
+            log_group=logs.LogGroup(
+                self,
+                f"{name}LogGroup",
+                log_group_name=f"/{self.props.name.lower()}/{name}",
+                retention=logs.RetentionDays.ONE_WEEK,
+            ),
+        )
+
+    def create_idle_watchdog_alarm(self) -> None:
+        """CloudWatch Alarm that stops the server after N idle minutes"""
+        evaluation_periods = self.props.idle_shutdown_minutes // 5
+
+        metric = cloudwatch.Metric(
+            namespace=self.props.cloudwatch_metric_namespace,
+            metric_name=self.props.cloudwatch_player_count_metric,
+            statistic="Maximum",
+            period=Duration.minutes(5),
+        )
+
+        alarm = cloudwatch.Alarm(
+            self,
+            self.qualify_name("IdleWatchdogAlarm"),
+            alarm_name=self.qualify_name("IdleWatchdogAlarm"),
+            metric=metric,
+            threshold=0,
+            comparison_operator=cloudwatch.ComparisonOperator.LESS_THAN_OR_EQUAL_TO_THRESHOLD,
+            evaluation_periods=evaluation_periods,
+            datapoints_to_alarm=evaluation_periods,
+            treat_missing_data=cloudwatch.TreatMissingData.BREACHING,
+        )
+
+        topic = sns.Topic(self, self.qualify_name("WatchdogTopic"))
+        topic.add_subscription(
+            sns_subscriptions.LambdaSubscription(self.task_count_lambda)
+        )
+        alarm.add_alarm_action(cw_actions.SnsAction(topic))

--- a/lib/stacks/game_stack.py
+++ b/lib/stacks/game_stack.py
@@ -1,7 +1,6 @@
 from functools import cached_property
 
 from aws_cdk import Duration, Stack, Tags
-from aws_cdk import aws_ssm as ssm
 from aws_cdk import aws_applicationautoscaling as appscaling
 from aws_cdk import aws_autoscaling as autoscaling
 from aws_cdk import aws_backup as backup
@@ -13,6 +12,7 @@ from aws_cdk import aws_events_targets as targets
 from aws_cdk import aws_iam as iam
 from aws_cdk import aws_lambda as _lambda
 from aws_cdk import aws_logs as logs
+from aws_cdk import aws_ssm as ssm
 from constructs import Construct
 
 from lib.aws_common.ec2 import create_security_group
@@ -455,6 +455,8 @@ class GameStack(Stack):
         """Lambda with Function URL for external start/stop webhook"""
         name = self.qualify_name("WebhookLambda")
         ssm_token_path = f"/{self.props.name.lower()}/webhook-token"
+        # SSM parameter ARNs omit the leading slash: arn:...:parameter/testgame/webhook-token
+        # Using resource_name with a leading slash would produce a double-slash ARN (wrong).
         ssm_token_arn = Stack.of(self).format_arn(
             service="ssm",
             resource="parameter",

--- a/test/config/test_game_properties.py
+++ b/test/config/test_game_properties.py
@@ -1,0 +1,52 @@
+import pytest
+
+from lib.config import GameProperties, GamePort, PortType, ServiceType
+
+
+BASE_KWARGS = dict(
+    name="TestGame",
+    container_image="img:latest",
+    container_path="/data",
+)
+
+
+def test_default_webhook_fields():
+    props = GameProperties(**BASE_KWARGS)
+    assert props.webhook_enabled is False
+    assert props.idle_shutdown_minutes == 20
+    assert props.cloudwatch_metric_namespace is None
+    assert props.cloudwatch_player_count_metric is None
+
+
+def test_both_cw_fields_set_is_valid():
+    props = GameProperties(
+        **BASE_KWARGS,
+        cloudwatch_metric_namespace="Minecraft",
+        cloudwatch_player_count_metric="players_online",
+    )
+    assert props.cloudwatch_metric_namespace == "Minecraft"
+
+
+def test_only_namespace_raises():
+    with pytest.raises(ValueError, match="cloudwatch"):
+        GameProperties(**BASE_KWARGS, cloudwatch_metric_namespace="Minecraft")
+
+
+def test_only_metric_raises():
+    with pytest.raises(ValueError, match="cloudwatch"):
+        GameProperties(**BASE_KWARGS, cloudwatch_player_count_metric="players_online")
+
+
+def test_idle_shutdown_minutes_must_be_multiple_of_5():
+    with pytest.raises(ValueError, match="idle_shutdown_minutes"):
+        GameProperties(**BASE_KWARGS, idle_shutdown_minutes=22)
+
+
+def test_idle_shutdown_minutes_must_be_positive():
+    with pytest.raises(ValueError, match="idle_shutdown_minutes"):
+        GameProperties(**BASE_KWARGS, idle_shutdown_minutes=0)
+
+
+def test_idle_shutdown_minutes_valid():
+    props = GameProperties(**BASE_KWARGS, idle_shutdown_minutes=15)
+    assert props.idle_shutdown_minutes == 15

--- a/test/config/test_game_properties.py
+++ b/test/config/test_game_properties.py
@@ -2,7 +2,6 @@ import pytest
 
 from lib.config import GameProperties, GamePort, PortType, ServiceType
 
-
 BASE_KWARGS = dict(
     name="TestGame",
     container_image="img:latest",

--- a/test/config/test_game_properties.py
+++ b/test/config/test_game_properties.py
@@ -1,6 +1,6 @@
 import pytest
 
-from lib.config import GameProperties, GamePort, PortType, ServiceType
+from lib.config import GamePort, GameProperties, PortType, ServiceType
 
 BASE_KWARGS = dict(
     name="TestGame",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -63,3 +63,20 @@ def webhook_game_properties() -> GameProperties:
         hosted_zone_id="Z00000000000000000000",
         webhook_enabled=True,
     )
+
+
+@pytest.fixture
+def watchdog_game_properties() -> GameProperties:
+    return GameProperties(
+        name="TestGame",
+        container_image="foobar-container/latest",
+        container_path="/data",
+        service_type=ServiceType.FARGATE,
+        ports=[GamePort(port_type=PortType.TCP, number=80)],
+        environment={"FOO": "BAR"},
+        domain_name="example.com",
+        hosted_zone_id="Z00000000000000000000",
+        cloudwatch_metric_namespace="Minecraft",
+        cloudwatch_player_count_metric="players_online",
+        idle_shutdown_minutes=20,
+    )

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,6 +1,12 @@
+import sys
+from pathlib import Path
+
 import pytest
 
 from lib.config import GamePort, GameProperties, PortType, ServiceType
+
+# Add lambda directory to sys.path so tests can import lambda functions
+sys.path.insert(0, str(Path(__file__).parent.parent / "lambda"))
 
 
 @pytest.fixture

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -48,3 +48,18 @@ def fargate_game_properties() -> GameProperties:
         domain_name="example.com",
         hosted_zone_id="Z00000000000000000000",
     )
+
+
+@pytest.fixture
+def webhook_game_properties() -> GameProperties:
+    return GameProperties(
+        name="TestGame",
+        container_image="foobar-container/latest",
+        container_path="/data",
+        service_type=ServiceType.FARGATE,
+        ports=[GamePort(port_type=PortType.TCP, number=80)],
+        environment={"FOO": "BAR"},
+        domain_name="example.com",
+        hosted_zone_id="Z00000000000000000000",
+        webhook_enabled=True,
+    )

--- a/test/lambda/test_ecs_desired_task_count.py
+++ b/test/lambda/test_ecs_desired_task_count.py
@@ -1,0 +1,78 @@
+import os
+from unittest.mock import MagicMock, patch
+
+
+def _get_handler():
+    with patch.dict(
+        os.environ,
+        {
+            "ECS_CLUSTER_ARN": "arn:aws:ecs:us-east-1:000000000000:cluster/TestCluster",
+            "ECS_SERVICE_NAME": "TestService",
+        },
+    ):
+        import ecs_desired_task_count
+        return ecs_desired_task_count
+
+
+_ENV = {
+    "ECS_CLUSTER_ARN": "arn:aws:ecs:us-east-1:000000000000:cluster/TestCluster",
+    "ECS_SERVICE_NAME": "TestService",
+}
+
+
+def test_stop_action_sets_desired_count_zero(monkeypatch):
+    mod = _get_handler()
+    ecs_mock = MagicMock()
+    for k, v in _ENV.items():
+        monkeypatch.setenv(k, v)
+    with patch("boto3.client", return_value=ecs_mock):
+        import importlib
+        importlib.reload(mod)
+        mod.handler({"action": "stop"}, None)
+    ecs_mock.update_service.assert_called_once_with(
+        cluster="arn:aws:ecs:us-east-1:000000000000:cluster/TestCluster",
+        service="TestService",
+        desiredCount=0,
+    )
+
+
+def test_start_action_sets_desired_count_one(monkeypatch):
+    mod = _get_handler()
+    ecs_mock = MagicMock()
+    for k, v in _ENV.items():
+        monkeypatch.setenv(k, v)
+    with patch("boto3.client", return_value=ecs_mock):
+        import importlib
+        importlib.reload(mod)
+        mod.handler({"action": "start"}, None)
+    ecs_mock.update_service.assert_called_once_with(
+        cluster="arn:aws:ecs:us-east-1:000000000000:cluster/TestCluster",
+        service="TestService",
+        desiredCount=1,
+    )
+
+
+def test_sns_envelope_defaults_to_stop(monkeypatch):
+    """SNS delivers a Records envelope with no top-level 'action' key.
+    The handler defaults to 'stop', which is the intended watchdog behavior."""
+    mod = _get_handler()
+    ecs_mock = MagicMock()
+    for k, v in _ENV.items():
+        monkeypatch.setenv(k, v)
+    sns_event = {
+        "Records": [
+            {
+                "EventSource": "aws:sns",
+                "Sns": {"Message": "CloudWatch alarm triggered"},
+            }
+        ]
+    }
+    with patch("boto3.client", return_value=ecs_mock):
+        import importlib
+        importlib.reload(mod)
+        mod.handler(sns_event, None)
+    ecs_mock.update_service.assert_called_once_with(
+        cluster="arn:aws:ecs:us-east-1:000000000000:cluster/TestCluster",
+        service="TestService",
+        desiredCount=0,
+    )

--- a/test/lambda/test_ecs_desired_task_count.py
+++ b/test/lambda/test_ecs_desired_task_count.py
@@ -11,6 +11,7 @@ def _get_handler():
         },
     ):
         import ecs_desired_task_count
+
         return ecs_desired_task_count
 
 
@@ -27,6 +28,7 @@ def test_stop_action_sets_desired_count_zero(monkeypatch):
         monkeypatch.setenv(k, v)
     with patch("boto3.client", return_value=ecs_mock):
         import importlib
+
         importlib.reload(mod)
         mod.handler({"action": "stop"}, None)
     ecs_mock.update_service.assert_called_once_with(
@@ -43,6 +45,7 @@ def test_start_action_sets_desired_count_one(monkeypatch):
         monkeypatch.setenv(k, v)
     with patch("boto3.client", return_value=ecs_mock):
         import importlib
+
         importlib.reload(mod)
         mod.handler({"action": "start"}, None)
     ecs_mock.update_service.assert_called_once_with(
@@ -69,6 +72,7 @@ def test_sns_envelope_defaults_to_stop(monkeypatch):
     }
     with patch("boto3.client", return_value=ecs_mock):
         import importlib
+
         importlib.reload(mod)
         mod.handler(sns_event, None)
     ecs_mock.update_service.assert_called_once_with(

--- a/test/lambda/test_ecs_webhook.py
+++ b/test/lambda/test_ecs_webhook.py
@@ -16,9 +16,7 @@ def _url_event(body: dict, token: str = "secret") -> dict:
 def _load_handler(ssm_token: str = "secret"):
     """Import ecs_webhook with a mocked SSM client returning ssm_token."""
     ssm_mock = MagicMock()
-    ssm_mock.get_parameter.return_value = {
-        "Parameter": {"Value": ssm_token}
-    }
+    ssm_mock.get_parameter.return_value = {"Parameter": {"Value": ssm_token}}
     boto3_mock = MagicMock()
     boto3_mock.client.return_value = ssm_mock
 
@@ -32,6 +30,7 @@ def _load_handler(ssm_token: str = "secret"):
     ):
         with patch("boto3.client", return_value=ssm_mock):
             import ecs_webhook
+
             importlib.reload(ecs_webhook)
             ecs_webhook._token = ssm_token  # inject cached token
     return ecs_webhook

--- a/test/lambda/test_ecs_webhook.py
+++ b/test/lambda/test_ecs_webhook.py
@@ -73,21 +73,27 @@ def test_stop_returns_200(monkeypatch):
 
 def test_missing_token_returns_403(monkeypatch):
     mod = _load_handler()
+    ecs_mock = MagicMock()
+    monkeypatch.setattr(mod, "_ecs_client", ecs_mock)
     event = _url_event({"action": "start"})
     del event["headers"]["x-webhook-token"]
 
     resp = mod.handler(event, None)
 
     assert resp["statusCode"] == 403
+    ecs_mock.update_service.assert_not_called()
 
 
 def test_wrong_token_returns_403(monkeypatch):
     mod = _load_handler()
+    ecs_mock = MagicMock()
+    monkeypatch.setattr(mod, "_ecs_client", ecs_mock)
     event = _url_event({"action": "start"}, token="wrong")
 
     resp = mod.handler(event, None)
 
     assert resp["statusCode"] == 403
+    ecs_mock.update_service.assert_not_called()
 
 
 def test_invalid_action_returns_400(monkeypatch):

--- a/test/lambda/test_ecs_webhook.py
+++ b/test/lambda/test_ecs_webhook.py
@@ -13,11 +13,6 @@ def _url_event(body: dict, token: str = "secret") -> dict:
     }
 
 
-# Helper to build a raw invocation event (no Function URL wrapper)
-def _raw_event(body: dict) -> dict:
-    return body
-
-
 def _load_handler(ssm_token: str = "secret"):
     """Import ecs_webhook with a mocked SSM client returning ssm_token."""
     ssm_mock = MagicMock()

--- a/test/lambda/test_ecs_webhook.py
+++ b/test/lambda/test_ecs_webhook.py
@@ -1,0 +1,111 @@
+import importlib
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+
+# Helper to build a Function URL event
+def _url_event(body: dict, token: str = "secret") -> dict:
+    return {
+        "requestContext": {"http": {"method": "POST"}},
+        "headers": {"x-webhook-token": token},
+        "body": json.dumps(body),
+    }
+
+
+# Helper to build a raw invocation event (no Function URL wrapper)
+def _raw_event(body: dict) -> dict:
+    return body
+
+
+def _load_handler(ssm_token: str = "secret"):
+    """Import ecs_webhook with a mocked SSM client returning ssm_token."""
+    ssm_mock = MagicMock()
+    ssm_mock.get_parameter.return_value = {
+        "Parameter": {"Value": ssm_token}
+    }
+    boto3_mock = MagicMock()
+    boto3_mock.client.return_value = ssm_mock
+
+    with patch.dict(
+        os.environ,
+        {
+            "ECS_CLUSTER_ARN": "arn:aws:ecs:us-east-1:000000000000:cluster/TestCluster",
+            "ECS_SERVICE_NAME": "TestService",
+            "WEBHOOK_TOKEN_SSM_PATH": "/test/webhook-token",
+        },
+    ):
+        with patch("boto3.client", return_value=ssm_mock):
+            import ecs_webhook
+            importlib.reload(ecs_webhook)
+            ecs_webhook._token = ssm_token  # inject cached token
+    return ecs_webhook
+
+
+def test_start_returns_200(monkeypatch):
+    mod = _load_handler()
+    ecs_mock = MagicMock()
+    monkeypatch.setattr(mod, "_ecs_client", ecs_mock)
+    monkeypatch.setenv("ECS_CLUSTER_ARN", "arn:aws:ecs:us-east-1:000000000000:cluster/TestCluster")
+    monkeypatch.setenv("ECS_SERVICE_NAME", "TestService")
+
+    resp = mod.handler(_url_event({"action": "start"}), None)
+
+    assert resp["statusCode"] == 200
+    body = json.loads(resp["body"])
+    assert body["desired_count"] == 1
+    ecs_mock.update_service.assert_called_once()
+
+
+def test_stop_returns_200(monkeypatch):
+    mod = _load_handler()
+    ecs_mock = MagicMock()
+    monkeypatch.setattr(mod, "_ecs_client", ecs_mock)
+    monkeypatch.setenv("ECS_CLUSTER_ARN", "arn:aws:ecs:us-east-1:000000000000:cluster/TestCluster")
+    monkeypatch.setenv("ECS_SERVICE_NAME", "TestService")
+
+    resp = mod.handler(_url_event({"action": "stop"}), None)
+
+    assert resp["statusCode"] == 200
+    body = json.loads(resp["body"])
+    assert body["desired_count"] == 0
+
+
+def test_missing_token_returns_403(monkeypatch):
+    mod = _load_handler()
+    event = _url_event({"action": "start"})
+    del event["headers"]["x-webhook-token"]
+
+    resp = mod.handler(event, None)
+
+    assert resp["statusCode"] == 403
+
+
+def test_wrong_token_returns_403(monkeypatch):
+    mod = _load_handler()
+    event = _url_event({"action": "start"}, token="wrong")
+
+    resp = mod.handler(event, None)
+
+    assert resp["statusCode"] == 403
+
+
+def test_invalid_action_returns_400(monkeypatch):
+    mod = _load_handler()
+    ecs_mock = MagicMock()
+    monkeypatch.setattr(mod, "_ecs_client", ecs_mock)
+
+    resp = mod.handler(_url_event({"action": "explode"}), None)
+
+    assert resp["statusCode"] == 400
+    ecs_mock.update_service.assert_not_called()
+
+
+def test_missing_action_returns_400(monkeypatch):
+    mod = _load_handler()
+    ecs_mock = MagicMock()
+    monkeypatch.setattr(mod, "_ecs_client", ecs_mock)
+
+    resp = mod.handler(_url_event({}), None)
+
+    assert resp["statusCode"] == 400

--- a/test/stacks/test_minecraft_stack.py
+++ b/test/stacks/test_minecraft_stack.py
@@ -60,7 +60,6 @@ def test_minecraft_fargate_service_public_ip_and_sg(fargate_game_properties: Gam
 
 
 def test_webhook_lambda_created(webhook_game_properties):
-    from lib.stacks.minecraft_stack import MinecraftStack
     app = App()
     env = Environment(account="000000000000", region="us-west-1")
     stack = MinecraftStack(scope=app, props=webhook_game_properties, env=env)
@@ -74,7 +73,6 @@ def test_webhook_lambda_created(webhook_game_properties):
 
 
 def test_webhook_function_url_created(webhook_game_properties):
-    from lib.stacks.minecraft_stack import MinecraftStack
     app = App()
     env = Environment(account="000000000000", region="us-west-1")
     stack = MinecraftStack(scope=app, props=webhook_game_properties, env=env)
@@ -88,7 +86,6 @@ def test_webhook_function_url_created(webhook_game_properties):
 
 
 def test_webhook_url_stored_in_ssm(webhook_game_properties):
-    from lib.stacks.minecraft_stack import MinecraftStack
     app = App()
     env = Environment(account="000000000000", region="us-west-1")
     stack = MinecraftStack(scope=app, props=webhook_game_properties, env=env)
@@ -101,7 +98,6 @@ def test_webhook_url_stored_in_ssm(webhook_game_properties):
 
 
 def test_webhook_not_created_when_disabled(fargate_game_properties):
-    from lib.stacks.minecraft_stack import MinecraftStack
     app = App()
     env = Environment(account="000000000000", region="us-west-1")
     stack = MinecraftStack(scope=app, props=fargate_game_properties, env=env)

--- a/test/stacks/test_minecraft_stack.py
+++ b/test/stacks/test_minecraft_stack.py
@@ -104,3 +104,56 @@ def test_webhook_not_created_when_disabled(fargate_game_properties):
     template = Template.from_stack(stack)
 
     template.resource_count_is("AWS::Lambda::Url", 0)
+
+
+def test_watchdog_alarm_created(watchdog_game_properties):
+    app = App()
+    env = Environment(account="000000000000", region="us-west-1")
+    stack = MinecraftStack(scope=app, props=watchdog_game_properties, env=env)
+    template = Template.from_stack(stack)
+
+    template.resource_count_is("AWS::CloudWatch::Alarm", 1)
+    template.has_resource_properties(
+        "AWS::CloudWatch::Alarm",
+        {
+            "Namespace": "Minecraft",
+            "MetricName": "players_online",
+            "Statistic": "Maximum",
+            "Period": 300,
+            "EvaluationPeriods": 4,
+            "DatapointsToAlarm": 4,
+            "Threshold": 0,
+            "TreatMissingData": "breaching",
+        },
+    )
+
+
+def test_watchdog_sns_topic_created(watchdog_game_properties):
+    app = App()
+    env = Environment(account="000000000000", region="us-west-1")
+    stack = MinecraftStack(scope=app, props=watchdog_game_properties, env=env)
+    template = Template.from_stack(stack)
+
+    template.resource_count_is("AWS::SNS::Topic", 1)
+
+
+def test_watchdog_task_count_lambda_created(watchdog_game_properties):
+    app = App()
+    env = Environment(account="000000000000", region="us-west-1")
+    stack = MinecraftStack(scope=app, props=watchdog_game_properties, env=env)
+    template = Template.from_stack(stack)
+
+    template.has_resource_properties(
+        "AWS::Lambda::Function",
+        {"FunctionName": "TestGameTaskCountLambda"},
+    )
+
+
+def test_watchdog_not_created_when_no_cw_fields(fargate_game_properties):
+    app = App()
+    env = Environment(account="000000000000", region="us-west-1")
+    stack = MinecraftStack(scope=app, props=fargate_game_properties, env=env)
+    template = Template.from_stack(stack)
+
+    template.resource_count_is("AWS::CloudWatch::Alarm", 0)
+    template.resource_count_is("AWS::SNS::Topic", 0)

--- a/test/stacks/test_minecraft_stack.py
+++ b/test/stacks/test_minecraft_stack.py
@@ -57,3 +57,54 @@ def test_minecraft_fargate_service_public_ip_and_sg(fargate_game_properties: Gam
             },
         },
     )
+
+
+def test_webhook_lambda_created(webhook_game_properties):
+    from lib.stacks.minecraft_stack import MinecraftStack
+    app = App()
+    env = Environment(account="000000000000", region="us-west-1")
+    stack = MinecraftStack(scope=app, props=webhook_game_properties, env=env)
+    template = Template.from_stack(stack)
+
+    # Lambda function named TestGameWebhookLambda
+    template.has_resource_properties(
+        "AWS::Lambda::Function",
+        {"FunctionName": "TestGameWebhookLambda"},
+    )
+
+
+def test_webhook_function_url_created(webhook_game_properties):
+    from lib.stacks.minecraft_stack import MinecraftStack
+    app = App()
+    env = Environment(account="000000000000", region="us-west-1")
+    stack = MinecraftStack(scope=app, props=webhook_game_properties, env=env)
+    template = Template.from_stack(stack)
+
+    template.resource_count_is("AWS::Lambda::Url", 1)
+    template.has_resource_properties(
+        "AWS::Lambda::Url",
+        {"AuthType": "NONE"},
+    )
+
+
+def test_webhook_url_stored_in_ssm(webhook_game_properties):
+    from lib.stacks.minecraft_stack import MinecraftStack
+    app = App()
+    env = Environment(account="000000000000", region="us-west-1")
+    stack = MinecraftStack(scope=app, props=webhook_game_properties, env=env)
+    template = Template.from_stack(stack)
+
+    template.has_resource_properties(
+        "AWS::SSM::Parameter",
+        {"Name": "/testgame/webhook-url", "Type": "String"},
+    )
+
+
+def test_webhook_not_created_when_disabled(fargate_game_properties):
+    from lib.stacks.minecraft_stack import MinecraftStack
+    app = App()
+    env = Environment(account="000000000000", region="us-west-1")
+    stack = MinecraftStack(scope=app, props=fargate_game_properties, env=env)
+    template = Template.from_stack(stack)
+
+    template.resource_count_is("AWS::Lambda::Url", 0)


### PR DESCRIPTION
## Summary

- Adds a Lambda Function URL webhook (`ecs_webhook.py`) to start/stop the ECS Fargate service on demand — pluggable into Discord, Telegram, Home Assistant, `curl`, etc.
- Adds a CloudWatch idle watchdog alarm that automatically stops the server after N minutes with zero players, using metrics from the existing Spigot-CloudWatch plugin
- Both features are opt-in via new `GameProperties` fields (`webhook_enabled`, `idle_shutdown_minutes`, `cloudwatch_metric_namespace`, `cloudwatch_player_count_metric`)

## Changes

- `lib/config/__init__.py` — 4 new fields + `__post_init__` validator on `GameProperties`
- `lib/aws_common/iam.py` — `ssm_get_parameter_policy` helper
- `lib/stacks/game_stack.py` — `create_webhook_lambda()`, `task_count_lambda` cached property, `create_idle_watchdog_alarm()`
- `lambda/ecs_webhook.py` — new webhook Lambda (token auth via `hmac.compare_digest`, SSM-cached secret)
- `lib/config/minecraft.py` — `webhook_enabled=True`; watchdog fields left commented until metric names confirmed in CloudWatch console
- Tests: 11 new test files / additions covering validator, webhook Lambda, task count Lambda, and CDK stack synthesis

## Security

- `X-Webhook-Token` validated with `hmac.compare_digest` (timing-safe)
- Token and Function URL stored in SSM — never appear in CloudFormation outputs or GitHub Actions logs
- SSM IAM grant scoped to exact parameter ARN

## Post-deploy operator steps

```bash
# 1. Set the webhook secret (once, after first deploy)
aws ssm put-parameter --name /minecraft/webhook-token --value "your-secret" --type SecureString

# 2. Retrieve the Function URL
aws ssm get-parameter --name /minecraft/webhook-url --query Parameter.Value --output text

# 3. Confirm CloudWatch metric names, then uncomment in lib/config/minecraft.py:
#    cloudwatch_metric_namespace="Minecraft"
#    cloudwatch_player_count_metric="players_online"
```

## Test plan

- [ ] `pytest` passes (33 tests, 0 failures)
- [ ] `cdk synth` produces no errors
- [ ] Post-deploy: set SSM token, retrieve URL, test with `curl -X POST <url> -H "X-Webhook-Token: <secret>" -d '{"action":"start"}'`
- [ ] Confirm CloudWatch metric names after server first run, update `minecraft.py`